### PR TITLE
Use PyPI's importlib_resources on Python up to (and including) 3.8.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ INSTALL_REQUIRES = [
     "httpx==0.14.3",
     "wheel==0.35.1",
     "pkginfo==1.5.0.1",
-    "importlib-resources==3.0.0;python_version<'3.8'",
+    "importlib-resources==3.0.0;python_version<'3.9'",
     "cookiecutter==1.7.2",
     "zstandard==0.14.0",
 ]

--- a/src/pup/plugins/mac/app_bundle.py
+++ b/src/pup/plugins/mac/app_bundle.py
@@ -10,7 +10,7 @@ from urllib import parse
 import cookiecutter
 from cookiecutter import generate
 try:
-    # Python < 3.8
+    # Python < 3.9
     import importlib_resources as ilr
 except ImportError:
     import importlib.resources as ilr

--- a/src/pup/plugins/win/dist_layout.py
+++ b/src/pup/plugins/win/dist_layout.py
@@ -10,7 +10,7 @@ from urllib import parse
 import cookiecutter
 from cookiecutter import generate
 try:
-    # Python < 3.8
+    # Python < 3.9
     import importlib_resources as ilr
 except ImportError:
     import importlib.resources as ilr


### PR DESCRIPTION
Fixes #35 on Windows.