### PR TITLE
macOS application bundle signing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ if __name__ == "__main__":
                 'mac.dirs=pup.plugins.mac.dirs:Directories',
                 'mac.steps=pup.plugins.mac.steps:Steps',
                 'mac.app_bundle_template=pup.plugins.mac.app_bundle:Step',
+                'mac.sign_app_bundle=pup.plugins.mac.sign:Step',
                 'win.dirs=pup.plugins.win.dirs:Directories',
                 'win.steps=pup.plugins.win.steps:Steps',
                 'win.distribution_layout=pup.plugins.win.dist_layout:Step',

--- a/src/pup/plugins/install_cleanup.py
+++ b/src/pup/plugins/install_cleanup.py
@@ -132,7 +132,6 @@ class Step:
             '-l',
             '-f',
             '-q',
-            '-b',
             None
         ]
 

--- a/src/pup/plugins/mac/sign.py
+++ b/src/pup/plugins/mac/sign.py
@@ -1,0 +1,98 @@
+"""
+PUP Plugin implementing the 'mac.sign-app-bundle' step.
+"""
+
+import logging
+import os
+import subprocess
+
+try:
+    # Python < 3.9
+    import importlib_resources as ilr
+except ImportError:
+    import importlib.resources as ilr
+
+from . import sign_resources
+
+
+
+_log = logging.getLogger(__name__)
+
+
+
+class Step:
+
+    @staticmethod
+    def usable_in(ctx):
+        return (
+            (ctx.pkg_platform == 'darwin') and
+            (ctx.tgt_platform == 'darwin')
+        )
+
+
+    def __init__(self):
+
+        self._codesign = None
+        self._entitlements = None
+
+    def __call__(self, ctx, dsp):
+
+        build_dir = dsp.directories()['build']
+        app_bundle_name = ctx.src_metadata.name
+        app_bundle_path = build_dir / f'{app_bundle_name}.app'
+
+        binaries_dir = (ctx.python_runtime_dir / ctx.python_rel_exe).parent
+
+        self._entitlements = ilr.files(sign_resources) / 'entitlements.plist'
+        codesign = subprocess.check_output('which codesign', shell=True, text=True)
+        self._codesign = codesign.rstrip('\n')
+
+        self._sign_framework_binaries(dsp, app_bundle_path)
+        self._sign_shared_libs(dsp, app_bundle_path)
+        self._sign_binaries(dsp, binaries_dir)
+        self._sign(dsp, app_bundle_path)
+
+
+    def _sign_framework_binaries(self, dsp, app_bundle_path):
+
+        for framework_path in app_bundle_path.glob('**/*.framework'):
+            for file_path in framework_path.glob('**/*'):
+                if file_path.is_file() and not file_path.is_symlink():
+                    self._sign(dsp, file_path)
+
+
+    def _sign_shared_libs(self, dsp, app_bundle_path):
+
+        for glob in ('*.so', '*.dylib'):
+            for shlib_path in app_bundle_path.glob(f'**/{glob}'):
+                self._sign(dsp, shlib_path)
+
+
+    def _sign_binaries(self, dsp, binaries_dir):
+
+        for file_path in binaries_dir.glob('*'):
+            if file_path.is_file() and not file_path.is_symlink():
+                self._sign(dsp, file_path)
+
+
+    def _sign(self, dsp, target):
+
+        cmd = [
+            self._codesign,
+            '--sign',
+            os.environ.get('PUP_SIGNING_IDENTITY', '-'),
+            '--entitlements',
+            str(self._entitlements),
+            '--deep',
+            str(target),
+            '--force',
+            '--options',
+            'runtime',
+            '--timestamp',
+        ]
+        _log.info('Signing %r...', str(target))
+        dsp.spawn(
+            cmd,
+            out_callable=lambda line: _log.info('codesign out: %s', line),
+            err_callable=lambda line: _log.info('codesign err: %s', line),
+        )

--- a/src/pup/plugins/mac/sign.py
+++ b/src/pup/plugins/mac/sign.py
@@ -51,6 +51,8 @@ class Step:
         self._sign_binaries(dsp, binaries_dir)
         self._sign(dsp, app_bundle_path)
 
+        self._assess_signing_result(dsp, app_bundle_path)
+
 
     def _cli_command_path(self, command):
 
@@ -102,3 +104,20 @@ class Step:
             out_callable=lambda line: _log.info('codesign out: %s', line),
             err_callable=lambda line: _log.info('codesign err: %s', line),
         )
+
+
+    def _assess_signing_result(self, dsp, app_bundle_path):
+
+        cmd = [
+            self._cli_command_path('spctl'),
+            '--assess',
+            '-vvvv',
+            str(app_bundle_path),
+        ]
+        _log.info('Assessing signing result...')
+        dsp.spawn(
+            cmd,
+            out_callable=lambda line: _log.info('spctl out: %s', line),
+            err_callable=lambda line: _log.info('spctl err: %s', line),
+        )
+        # TODO: Expect PIP_SIGNING_IDENTITY to be output? Warn if not?

--- a/src/pup/plugins/mac/sign.py
+++ b/src/pup/plugins/mac/sign.py
@@ -44,13 +44,19 @@ class Step:
         binaries_dir = (ctx.python_runtime_dir / ctx.python_rel_exe).parent
 
         self._entitlements = ilr.files(sign_resources) / 'entitlements.plist'
-        codesign = subprocess.check_output('which codesign', shell=True, text=True)
-        self._codesign = codesign.rstrip('\n')
+        self._codesign = self._cli_command_path('codesign')
 
         self._sign_framework_binaries(dsp, app_bundle_path)
         self._sign_shared_libs(dsp, app_bundle_path)
         self._sign_binaries(dsp, binaries_dir)
         self._sign(dsp, app_bundle_path)
+
+
+    def _cli_command_path(self, command):
+
+        shell_command = f'which "{command}"'
+        result = subprocess.check_output(shell_command, shell=True, text=True)
+        return result.rstrip('\n')
 
 
     def _sign_framework_binaries(self, dsp, app_bundle_path):

--- a/src/pup/plugins/mac/sign_resources/entitlements.plist
+++ b/src/pup/plugins/mac/sign_resources/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+</dict>
+</plist>

--- a/src/pup/plugins/mac/steps.py
+++ b/src/pup/plugins/mac/steps.py
@@ -18,7 +18,7 @@ class Steps:
             'pup.python-runtime',
             'pup.pip-install',
             'pup.install-cleanup',
-            # 'mac.sign-app-bundle',
+            'mac.sign-app-bundle',
             # 'mac.notarize-app-bundle',
             # 'mac.create-dmg',
         )


### PR DESCRIPTION
Addresses #43.

Thoughts:

* For now, grabs the SIGNING IDENTITY from the environment.
* Will want to support a command line option, too (instead?)...
* ...that's the focus of #14, so leaving it as is, for now.
