### PR TITLE
Fix launching macOS app bundles containing spaces in their names.

### DIFF
--- a/docs/newsfragments/41.bug
+++ b/docs/newsfragments/41.bug
@@ -1,0 +1,1 @@
+macOS application bundles with names containing spaces now launch.

--- a/src/pup/plugins/mac/app_bundle_template/{{cookiecutter.app_bundle_name}}.app/Contents/MacOS/{{cookiecutter.launcher_name}}
+++ b/src/pup/plugins/mac/app_bundle_template/{{cookiecutter.app_bundle_name}}.app/Contents/MacOS/{{cookiecutter.launcher_name}}
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec "$(dirname $0)/../Resources/Python/bin/python{{cookiecutter.python_version_suffix}}" -m {{cookiecutter.launch_module}} "$@"
+exec "$(dirname "$0")/../Resources/Python/bin/python{{cookiecutter.python_version_suffix}}" -m {{cookiecutter.launch_module}} "$@"


### PR DESCRIPTION
Fixes #44.
