### PR TITLE
Minimal macOS DMG file creation in place.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ INSTALL_REQUIRES = [
     "importlib-resources==3.0.0;python_version<'3.9'",
     "cookiecutter==1.7.2",
     "zstandard==0.14.0",
+    "dmgbuild==1.4.2",
 ]
 EXTRAS_REQUIRE = {
     "docs": [
@@ -118,6 +119,7 @@ if __name__ == "__main__":
                 'mac.app_bundle_template=pup.plugins.mac.app_bundle:Step',
                 'mac.sign_app_bundle=pup.plugins.mac.sign:Step',
                 'mac.notarize_app_bundle=pup.plugins.mac.notarize:Step',
+                'mac.create_dmg=pup.plugins.mac.create_dmg:Step',
                 'win.dirs=pup.plugins.win.dirs:Directories',
                 'win.steps=pup.plugins.win.steps:Steps',
                 'win.distribution_layout=pup.plugins.win.dist_layout:Step',

--- a/src/pup/plugins/mac/create_dmg.py
+++ b/src/pup/plugins/mac/create_dmg.py
@@ -1,0 +1,113 @@
+"""
+PUP Plugin implementing the 'mac.create-dmg' step.
+"""
+
+import logging
+import os
+import pathlib
+import shutil
+
+import cookiecutter
+from cookiecutter import generate
+try:
+    # Python < 3.9
+    import importlib_resources as ilr
+except ImportError:
+    import importlib.resources as ilr
+
+from . import dmgbuild_settings_template
+
+
+
+_log = logging.getLogger(__name__)
+
+
+
+class Step:
+
+    """
+    Uses `dmgbuild` to create a DMG image of the application bundle.
+    """
+
+    @staticmethod
+    def usable_in(ctx):
+        return (
+            (ctx.pkg_platform == 'darwin') and
+            (ctx.tgt_platform == 'darwin')
+        )
+
+    def __call__(self, ctx, dsp):
+
+        volume_name = f'{ctx.src_metadata.name} {ctx.src_metadata.version}'
+        filename = f'{volume_name}.dmg'
+
+        settings_path = self._create_dmgbuild_settings(ctx, dsp, volume_name, filename)
+        self._create_dmg_file(ctx, dsp, settings_path)
+        self._deliver_dmg_file(dsp, settings_path, filename)
+
+
+    def _create_dmgbuild_settings(self, ctx, dsp, volume_name, filename):
+
+        tmpl_path = ilr.files(dmgbuild_settings_template)
+        tmpl_data = {
+            'cookiecutter': {
+                'app_name': ctx.src_metadata.name,
+                'volume_name': volume_name,
+                'filename': filename,
+                'app_bundle_name': f'{ctx.src_metadata.name}.app',
+            }
+        }
+
+        # "Generate + Remove + Generate" motivation: cookiecutter either fails
+        # if the output path exists, or overwrites it. However, it does not
+        # remove pre-existing files that are no longer templated. Thus, the
+        # "proper" way to ensure output is consistent without deleting the
+        # whole build directory is to "Generate + Remove + Generate again".
+
+        build_dir = dsp.directories()['build']
+        result_path = generate.generate_files(tmpl_path, tmpl_data, build_dir, overwrite_if_exists=True)
+        shutil.rmtree(result_path, ignore_errors=True)
+        result_path = generate.generate_files(tmpl_path, tmpl_data, build_dir)
+
+        return pathlib.Path(result_path)
+
+
+    def _create_dmg_file(self, ctx, dsp, settings_path):
+
+        # The `dmgbuild` settings file includes relative paths that require
+        # us launching it with its directory as the CWD.
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(str(settings_path))
+
+            cmd = [
+                'dmgbuild',
+                '-s', 'settings.py',
+                # Both overridden in the settings file.
+                'volume-name',
+                'output.dmg',
+            ]
+            dsp.spawn(
+                cmd,
+                out_callable=lambda line: _log.info('dmgbuild out: %s', line),
+                err_callable=lambda line: _log.info('dmgbuild err: %s', line),
+            )
+        finally:
+            os.chdir(cwd)
+
+
+    def _deliver_dmg_file(self, dsp, path, filename):
+
+        dist_dir = dsp.directories()['dist']
+        dist_dir.mkdir(exist_ok=True)
+
+        try:
+            # Move file to file instead of file to dir ensures overwrites;
+            # otherwise, move fails if file exists on destination dir.
+            shutil.move(
+                path / filename,
+                dist_dir / filename,
+            )
+        except OSError as exc:
+            _log.error('%s', exc)

--- a/src/pup/plugins/mac/dmgbuild_settings_template/{{cookiecutter.app_name}}.dmgbuild/settings.py
+++ b/src/pup/plugins/mac/dmgbuild_settings_template/{{cookiecutter.app_name}}.dmgbuild/settings.py
@@ -1,0 +1,22 @@
+volume_name = '{{cookiecutter.volume_name}}'
+filename = '{{cookiecutter.filename}}'
+
+app_bundle = '{{cookiecutter.app_bundle_name}}'
+
+files = [
+    f'../{app_bundle}',
+]
+symlinks = {
+    'Applications': '/Applications',
+}
+
+default_view = 'icon-view'
+background = 'builtin-arrow'
+
+text_size = 14
+icon_size = 96
+
+icon_locations = {
+    'Applications': (500, 120),
+    app_bundle: (140, 120),
+}

--- a/src/pup/plugins/mac/steps.py
+++ b/src/pup/plugins/mac/steps.py
@@ -20,6 +20,5 @@ class Steps:
             'pup.install-cleanup',
             'mac.sign-app-bundle',
             'mac.notarize-app-bundle',
-            # 'mac.notarize-app-bundle',
-            # 'mac.create-dmg',
+            'mac.create-dmg',
         )


### PR DESCRIPTION
Addresses #66

THOUGHTS:

* Went with `dmgbuild` which seems to do everything we want out of the box.
  (except having a documented API -- thus, we spawn a process instead of calling it directly) ;-(

OUTSTANDING:

* Nice application name #41.
* Nice icons #90.
* Displaying a license agreement on opening #91. 