### PR TITLE
macOS signing and notarizing now works with --nice-name.

### DIFF
--- a/src/pup/plugins/mac/notarize.py
+++ b/src/pup/plugins/mac/notarize.py
@@ -39,7 +39,7 @@ class Step:
     def _notarize(self, ctx, dsp, user, password):
 
         build_dir = dsp.directories()['build']
-        app_bundle_name = ctx.src_metadata.name
+        app_bundle_name = ctx.nice_name
         app_bundle_path = build_dir / f'{app_bundle_name}.app'
 
         app_bundle_zip = self._create_app_bundle_zip(dsp, app_bundle_path)

--- a/src/pup/plugins/mac/sign.py
+++ b/src/pup/plugins/mac/sign.py
@@ -45,7 +45,7 @@ class Step:
             return
 
         build_dir = dsp.directories()['build']
-        app_bundle_name = ctx.src_metadata.name
+        app_bundle_name = ctx.nice_name
         app_bundle_path = build_dir / f'{app_bundle_name}.app'
 
         binaries_dir = (ctx.python_runtime_dir / ctx.python_rel_exe).parent


### PR DESCRIPTION
Fixes #111.