### PR TITLE
Fix running tkinter/turtle on macOS from within a venv.

### DIFF
--- a/docs/newsfragments/122.bug
+++ b/docs/newsfragments/122.bug
@@ -1,0 +1,1 @@
+macOS packaged applications failed running ``tkinter`` and ``turtle`` code when such code was running under a virtual environment -- much like what Mu Editor does. Now fixed.

--- a/src/pup/context.py
+++ b/src/pup/context.py
@@ -48,6 +48,7 @@ class Context:
         self.python_rel_scripts = None
         self.python_rel_stdlib = None
         self.python_rel_site_packages = None
+        self.python_rel_tcl_library = None
 
         self.final_artifact = None
 

--- a/src/pup/plugins/mac/app_bundle.py
+++ b/src/pup/plugins/mac/app_bundle.py
@@ -51,7 +51,8 @@ class Step:
                 'version_string': ctx.src_metadata.version,
                 'copyright': self._copyright_from_context(ctx),
                 'launcher_name': ctx.nice_name,
-                'python_version_suffix': ctx.tgt_python_version_suffix,
+                'tcl_library': str(ctx.python_rel_tcl_library),
+                'python_rel_exe': str(ctx.python_rel_exe),
                 'launch_module': self._launch_module_from_context(ctx),
             }
         }

--- a/src/pup/plugins/mac/app_bundle_template/{{cookiecutter.app_bundle_name}}.app/Contents/MacOS/{{cookiecutter.launcher_name}}
+++ b/src/pup/plugins/mac/app_bundle_template/{{cookiecutter.app_bundle_name}}.app/Contents/MacOS/{{cookiecutter.launcher_name}}
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-exec "$(dirname "$0")/../Resources/Python/bin/python{{cookiecutter.python_version_suffix}}" -m {{cookiecutter.launch_module}} "$@"
+export TCL_LIBRARY="$(dirname "$0")/../Resources/Python/{{cookiecutter.tcl_library}}"
+exec "$(dirname "$0")/../Resources/Python/{{cookiecutter.python_rel_exe}}" -m {{cookiecutter.launch_module}} "$@"

--- a/src/pup/plugins/python_runtime.py
+++ b/src/pup/plugins/python_runtime.py
@@ -71,6 +71,18 @@ class Step:
         ctx.python_rel_stdlib = self._relative(pbs_py_paths['stdlib'], pbs_data)
         ctx.python_rel_site_packages = self._relative(pbs_py_paths['purelib'], pbs_data)
 
+        # Find `init.tcl` path (macOS needs the TCL_LIBRARY env var set).
+        tcl_library_path = pbs_py_dir / pbs_py_json['tcl_library_path']
+        init_tcl_path = None
+        for candidate_path in pbs_py_json['tcl_library_paths']:
+            init_tcl_path = tcl_library_path / candidate_path / 'init.tcl'
+            if init_tcl_path.exists():
+                break
+        ctx.python_rel_tcl_library = self._relative(
+            self._relative(init_tcl_path.parent, pbs_py_dir),
+            pbs_data,
+        )
+
 
     def _ensure_build_dir(self, dsp):
 


### PR DESCRIPTION
Fixes #122 by setting the `TCL_LIBRARY` environment variable on the startup script.