### PR TITLE
Fix macOS signing: add `entitlements.plist` to pup's distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 recursive-include src/pup/plugins/mac/app_bundle_template *
 recursive-include src/pup/plugins/mac/dmgbuild_settings_template *
+recursive-include src/pup/plugins/mac/sign_resources *
 recursive-include src/pup/plugins/win/dist_layout_template *
 recursive-include src/pup/plugins/win/msi_wxs_template *
 global-exclude *.pyc

--- a/docs/newsfragments/138.bug
+++ b/docs/newsfragments/138.bug
@@ -1,0 +1,7 @@
+An ``entitlements.plist`` file,
+required for the macOS signing process,
+is now bundled.
+Previously distributed versions unintentionally failed to do that,
+preventing the successful signature
+and subsequent notarization
+of packaged applications on macOS.


### PR DESCRIPTION
Addresses #138.