### PR TITLE
macOS signing now recurses into bundled wheel and ZIP files.

### DIFF
--- a/docs/newsfragments/156.bug
+++ b/docs/newsfragments/156.bug
@@ -1,0 +1,1 @@
+Fixed macOS signing of bundled files to support Mu Editor 1.0.0b5 that ships Python wheels within a ZIP file. The signing process now recurses into both wheel and ZIP files.


### PR DESCRIPTION
Fixes #156.