### PR TITLE
Update Python Standalone URLs to latest 3.8 release

### DIFF
--- a/docs/newsfragments/169.other
+++ b/docs/newsfragments/169.other
@@ -1,0 +1,3 @@
+Updated the Python Standalone 3.8 bundle from 3.8.5 to 3.8.11.
+The Python 3.7 version configured is untouched as 3.7.9 is
+already the latest version available.

--- a/src/pup/plugins/python_runtime.py
+++ b/src/pup/plugins/python_runtime.py
@@ -20,11 +20,11 @@ _log = logging.getLogger(__name__)
 _PYTHON_BUILD_STANDALONE_URLs = {
     'darwin': {
         '3.7': 'https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.7.9-x86_64-apple-darwin-pgo-20200823T2228.tar.zst',
-        '3.8': 'https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.8.5-x86_64-apple-darwin-pgo-20200823T2228.tar.zst',
+        '3.8': 'https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo-20210724T1424.tar.zst',
     },
     'win32': {
         '3.7': 'https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-pc-windows-msvc-shared-pgo-20200823T0118.tar.zst',
-        '3.8': 'https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-x86_64-pc-windows-msvc-shared-pgo-20200830T2254.tar.zst',
+        '3.8': 'https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst',
     },
 }
 


### PR DESCRIPTION
In case this resolves some odd issues reported by users.

I'm not targetting any specific issue with this update, but it's worth doing in case it does fix some of the hard to diagnose issues.

https://github.com/indygreg/python-build-standalone/releases/tag/20210724