### PR TITLE
macOS binary launcher now backwards compatible to 10.9.

### DIFF
--- a/docs/newsfragments/177.bug
+++ b/docs/newsfragments/177.bug
@@ -1,0 +1,4 @@
+With the new binary launcher in release 1.0.0a11,
+macOS packaged applications are no longer backwards compatible:
+applications packaged in 10.15 do not launch on 10.14, for example.
+This is an attempt at fixing that.

--- a/src/pup/plugins/mac/launcher.py
+++ b/src/pup/plugins/mac/launcher.py
@@ -31,6 +31,7 @@ class Step:
             os.chdir(launcher_path)
             dsp.spawn([
                 shutil.which('clang'),
+                '-mmacosx-version-min=10.9',
                 '-o',
                 ctx.nice_name,
                 'launcher.c',


### PR DESCRIPTION
Attempt at fixing #177.