### PR TITLE
macOS binary launcher fix: properly terminate execv argv array.

### DIFF
--- a/docs/newsfragments/185.bug
+++ b/docs/newsfragments/185.bug
@@ -1,0 +1,3 @@
+The macOS binary launcher introduced in release 1.0.0a11
+failed on Apple Silicon systems.
+Now fixed.

--- a/src/pup/plugins/mac/app_bundle_template/{{cookiecutter.app_bundle_name}}.app/Contents/MacOS/launcher.c
+++ b/src/pup/plugins/mac/app_bundle_template/{{cookiecutter.app_bundle_name}}.app/Contents/MacOS/launcher.c
@@ -36,7 +36,7 @@ int main() {
     putenv(tcl_lib_env);
 
     snprintf(python_path, PATH_BUFFER_SIZE, "%s/../Resources/Python/bin/%s", launcher_dir, nice_name);
-    char * args[] = {nice_name, "-m" , "{{cookiecutter.launch_module}}"};
+    char * args[] = {nice_name, "-m" , "{{cookiecutter.launch_module}}", NULL};
     if ( execv(python_path, args) ) {
         fprintf(stderr, "execv(\"%s\") failed: %s.\n", python_path, strerror(errno));
     }


### PR DESCRIPTION
Addresses #185.