### PR TITLE
Default to launch with -I, support other options.

### DIFF
--- a/docs/newsfragments/195.bug
+++ b/docs/newsfragments/195.bug
@@ -1,0 +1,3 @@
+Package applications are now launched with the ``-I`` Python CLI flag.
+This isolates them from the users' site packages directory and environment.
+Can be overridden with the new ``--launch-pyflag`` packaging option.

--- a/src/pup/__main__.py
+++ b/src/pup/__main__.py
@@ -68,12 +68,13 @@ def main(log_level):
 @main.command()
 @click.option('--ignore-plugin', 'ignore_plugins', multiple=True)
 @click.option('--launch-module')
+@click.option('--launch-pyflag', 'launch_pyflags', multiple=True, default=['-I',])
 @click.option('--nice-name')
 @click.option('--icon-path')
 @click.option('--license-path')
 @click.argument('src')
 @command_wrapper
-def package(src, ignore_plugins, launch_module, nice_name, icon_path, license_path):
+def package(src, ignore_plugins, launch_module, launch_pyflags, nice_name, icon_path, license_path):
     """
     Packages the GUI application in the given pip-installable source.
     """
@@ -81,6 +82,7 @@ def package(src, ignore_plugins, launch_module, nice_name, icon_path, license_pa
         src,
         ignore_plugins=ignore_plugins,
         launch_module=launch_module,
+        launch_pyflags=launch_pyflags,
         nice_name=nice_name,
         icon_path=icon_path,
         license_path=license_path,

--- a/src/pup/api.py
+++ b/src/pup/api.py
@@ -19,6 +19,7 @@ def _context(
     ignore_plugins,
     src=None,
     launch_module=None,
+    launch_pyflags=None,
     nice_name=None,
     icon_path=None,
     license_path=None,
@@ -27,6 +28,7 @@ def _context(
     return context.Context(
         src=src,
         launch_module=launch_module,
+        launch_pyflags=launch_pyflags,
         nice_name=nice_name,
         icon_path=icon_path,
         license_path=license_path,
@@ -42,6 +44,7 @@ def package(
     *,
     ignore_plugins=(),
     launch_module=None,
+    launch_pyflags=None,
     nice_name=None,
     icon_path=None,
     license_path=None,
@@ -49,7 +52,7 @@ def package(
 
     _log.info('Package %r: starting.', src)
 
-    ctx = _context(ignore_plugins, src, launch_module, nice_name, icon_path, license_path)
+    ctx = _context(ignore_plugins, src, launch_module, launch_pyflags, nice_name, icon_path, license_path)
     dsp = dispatcher.Dispatcher(ctx)
 
     dsp.collect_src_metadata()

--- a/src/pup/context.py
+++ b/src/pup/context.py
@@ -13,6 +13,7 @@ class Context:
         *,
         src,
         launch_module,
+        launch_pyflags,
         nice_name,
         icon_path,
         license_path,
@@ -23,6 +24,7 @@ class Context:
 
         self.src = src
         self.launch_module = launch_module
+        self.launch_pyflags = launch_pyflags
         self._nice_name = nice_name
         self.icon_path = pathlib.Path(icon_path).absolute() if icon_path else None
         self.license_path = pathlib.Path(license_path).absolute() if license_path else None

--- a/src/pup/context.py
+++ b/src/pup/context.py
@@ -24,7 +24,7 @@ class Context:
 
         self.src = src
         self.launch_module = launch_module
-        self.launch_pyflags = launch_pyflags
+        self.launch_pyflags = tuple(pyflag for pyflag in launch_pyflags if pyflag)
         self._nice_name = nice_name
         self.icon_path = pathlib.Path(icon_path).absolute() if icon_path else None
         self.license_path = pathlib.Path(license_path).absolute() if license_path else None

--- a/src/pup/plugins/linux/appdir_layout.py
+++ b/src/pup/plugins/linux/appdir_layout.py
@@ -36,6 +36,7 @@ class Step:
             'cookiecutter': {
                 'nice_name': ctx.nice_name,
                 'launch_module': self._launch_module_from_context(ctx),
+                'launch_pyflags': ' '.join(ctx.launch_pyflags),
                 'python_exe': ctx.python_rel_exe.name,
                 'tcl_library': ctx.python_rel_tcl_library,
                 'categories': 'Education',

--- a/src/pup/plugins/linux/appdir_template/{{cookiecutter.nice_name}}.AppDir/AppRun
+++ b/src/pup/plugins/linux/appdir_template/{{cookiecutter.nice_name}}.AppDir/AppRun
@@ -3,4 +3,4 @@
 THIS_DIR="$(dirname "$(readlink -f "${0}")")"
 export TCL_LIBRARY="${THIS_DIR}/usr/{{cookiecutter.tcl_library}}"
 
-exec "${THIS_DIR}/usr/bin/{{cookiecutter.python_exe}}" -m {{cookiecutter.launch_module}}
+exec "${THIS_DIR}/usr/bin/{{cookiecutter.python_exe}}" {{cookiecutter.launch_pyflags}} -m {{cookiecutter.launch_module}}

--- a/src/pup/plugins/mac/app_bundle.py
+++ b/src/pup/plugins/mac/app_bundle.py
@@ -53,6 +53,7 @@ class Step:
                 'copyright': self._copyright_from_context(ctx),
                 'launcher_name': ctx.nice_name,
                 'launch_module': self._launch_module_from_context(ctx),
+                'launch_pyflags': ''.join(f'"{pyflag}",' for pyflag in ctx.launch_pyflags),
             }
         }
 

--- a/src/pup/plugins/mac/app_bundle_template/{{cookiecutter.app_bundle_name}}.app/Contents/MacOS/launcher.c
+++ b/src/pup/plugins/mac/app_bundle_template/{{cookiecutter.app_bundle_name}}.app/Contents/MacOS/launcher.c
@@ -36,7 +36,13 @@ int main() {
     putenv(tcl_lib_env);
 
     snprintf(python_path, PATH_BUFFER_SIZE, "%s/../Resources/Python/bin/%s", launcher_dir, nice_name);
-    char * args[] = {nice_name, "-m" , "{{cookiecutter.launch_module}}", NULL};
+    char * args[] = {
+        nice_name,
+        {{cookiecutter.launch_pyflags}}
+        "-m",
+        "{{cookiecutter.launch_module}}",
+        NULL
+    };
     if ( execv(python_path, args) ) {
         fprintf(stderr, "execv(\"%s\") failed: %s.\n", python_path, strerror(errno));
     }

--- a/src/pup/plugins/win/create_msi.py
+++ b/src/pup/plugins/win/create_msi.py
@@ -104,6 +104,7 @@ class Step:
                 'author_email': ctx.src_metadata.author_email,
                 'url': ctx.src_metadata.home_page,
                 'launch_module': self._launch_module_from_context(ctx),
+                'launch_pyflags': ' '.join(pyflag for pyflag in ctx.launch_pyflags),
                 'guid': self._upgrade_code_guid(ctx),
                 'pythonw_exe_file_id': pythonw_exe_file_id,
             }

--- a/src/pup/plugins/win/dist_layout.py
+++ b/src/pup/plugins/win/dist_layout.py
@@ -50,6 +50,7 @@ class Step:
                 'app_name': ctx.nice_name,
                 'version': ctx.src_metadata.version,
                 'launch_module': self._launch_module_from_context(ctx),
+                'launch_pyflags': ' '.join(pyflag for pyflag in ctx.launch_pyflags),
             }
         }
 

--- a/src/pup/plugins/win/dist_layout_template/{{cookiecutter.app_name}} {{cookiecutter.version}}/{{cookiecutter.app_name}}.vbs
+++ b/src/pup/plugins/win/dist_layout_template/{{cookiecutter.app_name}} {{cookiecutter.version}}/{{cookiecutter.app_name}}.vbs
@@ -1,6 +1,6 @@
 Set objShell = CreateObject("WScript.Shell")
 
 thisFilePath = Replace(WScript.ScriptFullName, WScript.ScriptName, "")
-commandToRun = """" & thisFilePath & "Python\pythonw.exe"" -m {{cookiecutter.launch_module}}"
+commandToRun = """" & thisFilePath & "Python\pythonw.exe"" {{cookiecutter.launch_pyflags}} -m {{cookiecutter.launch_module}}"
 
 objShell.Run(commandToRun)

--- a/src/pup/plugins/win/msi_wxs_template/{{cookiecutter.app_name}} {{cookiecutter.version}}.wix-sources/{{cookiecutter.app_name}} {{cookiecutter.version}}.wxs
+++ b/src/pup/plugins/win/msi_wxs_template/{{cookiecutter.app_name}} {{cookiecutter.version}}.wix-sources/{{cookiecutter.app_name}} {{cookiecutter.version}}.wxs
@@ -64,7 +64,7 @@
                             {% endif %}
                             Target="[{{ cookiecutter.launch_module }}_ROOTDIR]python\pythonw.exe"
                             WorkingDirectory="{{ cookiecutter.launch_module }}_ROOTDIR"
-                            Arguments="-m {{ cookiecutter.launch_module }}" />
+                            Arguments="{{ cookiecutter.launch_pyflags }} -m {{ cookiecutter.launch_module }}" />
                     <RegistryValue
                             Root="HKCU"
                             Key="Software\{{ cookiecutter.author }}\{{ cookiecutter.app_name }}"

--- a/src/pup/plugins/win/msi_wxs_template/{{cookiecutter.app_name}} {{cookiecutter.version}}.wix-sources/{{cookiecutter.app_name}} {{cookiecutter.version}}.wxs
+++ b/src/pup/plugins/win/msi_wxs_template/{{cookiecutter.app_name}} {{cookiecutter.version}}.wix-sources/{{cookiecutter.app_name}} {{cookiecutter.version}}.wxs
@@ -108,7 +108,7 @@
         <CustomAction Id="LaunchApplication"
                       Impersonate="yes"
                       FileKey="{{ cookiecutter.pythonw_exe_file_id }}"
-                      ExeCommand="-m {{ cookiecutter.launch_module }}"
+                      ExeCommand="{{ cookiecutter.launch_pyflags }} -m {{ cookiecutter.launch_module }}"
                       Return="asyncNoWait"
                       />
 


### PR DESCRIPTION
Addresses #195 and #42.

Hand tested with `puppy` on Linux, macOS, and Windows.