### PR TITLE
201 linux appimage under docker

### DIFF
--- a/docs/newsfragments/201.bug
+++ b/docs/newsfragments/201.bug
@@ -1,0 +1,1 @@
+Fixed Linux AppDir packaging under docker containers.

--- a/src/pup/plugins/linux/appdir_create.py
+++ b/src/pup/plugins/linux/appdir_create.py
@@ -77,4 +77,4 @@ class Step:
         # The embedded entry point:
         appimage_tool = appimage_tool_dir / 'squashfs-root' / 'AppRun'
 
-        return appimage_tool
+        return appimage_tool.absolute()

--- a/src/pup/plugins/linux/appdir_create.py
+++ b/src/pup/plugins/linux/appdir_create.py
@@ -24,7 +24,7 @@ class Step:
         dist_dir.mkdir(parents=True, exist_ok=True)
 
         appdir_src = (build_dir / f'{ctx.nice_name}.AppDir').absolute()
-        appimage_tool = self._ensure_appimage_tool(dsp)
+        appimage_tool = self._ensure_appimage_tool(dsp, build_dir)
 
         cwd = os.getcwd()
         try:
@@ -47,8 +47,34 @@ class Step:
         '/releases/download/13/appimagetool-x86_64.AppImage'
     )
 
-    def _ensure_appimage_tool(self, dsp):
+    def _ensure_appimage_tool(self, dsp, build_dir):
 
         appimage_tool = dsp.download(self._APPIMAGE_TOOL_URL)
         appimage_tool.chmod(0o555)
+
+        # The downloaded tool is itself an AppImage that fails to run under
+        # Docker containers. Workaround: extract the AppImage and return the
+        # embedded command/entrypoint.
+
+        appimage_tool_dir = build_dir / 'appimagetool'
+        appimage_tool_dir.mkdir(parents=True, exist_ok=True)
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(appimage_tool_dir)
+            cmd = [
+                str(appimage_tool),
+                '--appimage-extract',
+            ]
+            dsp.spawn(
+                cmd,
+                out_callable=lambda line: _log.info('appimagetool out: %s', line),
+                err_callable=lambda line: _log.info('appimagetool err: %s', line),
+            )
+        finally:
+            os.chdir(cwd)
+
+        # The embedded entry point:
+        appimage_tool = appimage_tool_dir / 'squashfs-root' / 'AppRun'
+
         return appimage_tool


### PR DESCRIPTION
Addresses #201.

* Hand tested with `puppy` on Linux.
* Not tested on Docker, but should work given that the `appimagetool` was confirmed to run within a Docker container after being `--appimage-extract`ed.
