### PR TITLE
Proof of concept: Add `--pip-platform` flag.

### DIFF
--- a/src/pup/__main__.py
+++ b/src/pup/__main__.py
@@ -73,9 +73,10 @@ def main(log_level):
 @click.option('--nice-name')
 @click.option('--icon-path')
 @click.option('--license-path')
+@click.option('--pip-platform', default=None)
 @click.argument('src')
 @command_wrapper
-def package(src, ignore_plugins, python_version, launch_module, launch_pyflags, nice_name, icon_path, license_path):
+def package(src, ignore_plugins, python_version, launch_module, launch_pyflags, nice_name, icon_path, license_path, pip_platform):
     """
     Packages the GUI application in the given pip-installable source.
     """
@@ -88,4 +89,5 @@ def package(src, ignore_plugins, python_version, launch_module, launch_pyflags, 
         nice_name=nice_name,
         icon_path=icon_path,
         license_path=license_path,
+        pip_platform=pip_platform,
     )

--- a/src/pup/api.py
+++ b/src/pup/api.py
@@ -24,6 +24,7 @@ def _context(
     nice_name=None,
     icon_path=None,
     license_path=None,
+    pip_platform=None,
 ):
 
     return context.Context(
@@ -35,6 +36,7 @@ def _context(
         license_path=license_path,
         ignore_plugins=ignore_plugins,
         platform=sys.platform,
+        pip_platform=pip_platform,
         python_version=python_version,
     )
 
@@ -50,11 +52,12 @@ def package(
     nice_name=None,
     icon_path=None,
     license_path=None,
+    pip_platform=None,
 ):
 
     _log.info('Package %r: starting.', src)
 
-    ctx = _context(ignore_plugins, src, python_version, launch_module, launch_pyflags, nice_name, icon_path, license_path)
+    ctx = _context(ignore_plugins, src, python_version, launch_module, launch_pyflags, nice_name, icon_path, license_path, pip_platform)
     dsp = dispatcher.Dispatcher(ctx)
 
     dsp.collect_src_metadata()

--- a/src/pup/context.py
+++ b/src/pup/context.py
@@ -19,6 +19,7 @@ class Context:
         license_path,
         ignore_plugins,
         platform,
+        pip_platform,
         python_version,
     ):
 
@@ -51,6 +52,8 @@ class Context:
         self.python_rel_tcl_library = None
 
         self.final_artifact = None
+
+        self.pip_platform = pip_platform
 
 
     @property


### PR DESCRIPTION
- For issue: https://github.com/mu-editor/pup/issues/245

This PR is a proof of concept to add a `pip-platform` flag to pup to pass its value to the `pip install` command, so that it fetches wheels for a specific platform.

This will make it possible to install wheels for older operating system versions than the system running pup.

For example: `pup ... --pip-platform=macosx_10_12_x86_64`